### PR TITLE
Adding in prepack to re-copy the package.json prior to npm publish.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:env": "LOAD_ENV=1 yarn test",
     "test:ci": "yarn lint && yarn type-check && yarn test",
     "build": "tsc -p tsconfig.dist.json --declaration && cp README.md dist/README.md && cp -r jupiterone/ dist/jupiterone/",
-    "prepush": "yarn lint && yarn type-check && jest --changedSince main"
+    "prepush": "yarn lint && yarn type-check && jest --changedSince main",
+    "prepack": "cp package.json dist/package.json"
   },
   "peerDependencies": {
     "@jupiterone/integration-sdk-core": "^8.8.0"
@@ -46,7 +47,8 @@
       [
         "npm",
         {
-          "setRcToken": false
+          "setRcToken": false,
+          "publishFolder": "./dist"
         }
       ],
       "released"


### PR DESCRIPTION
I believe the issue we're hitting with specifying a publishFolder value in `auto shipit` is that this is the current order of operations for shipit:

- `yarn build` runs to build the project into the ./dist folder
- auto shipit calculates the version to bump to.
- auto shipit performs the action to update package.json
- auto shipit runs `npm publish ./dist`, but the ./dist folder still contains the old package.json file with the old version.

I believe the addition of a simple prepack command to re-copy the package.json file will remedy this.