### PR TITLE
Switching to postversion for re-copying package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:ci": "yarn lint && yarn type-check && yarn test",
     "build": "tsc -p tsconfig.dist.json --declaration && cp README.md dist/README.md && cp -r jupiterone/ dist/jupiterone/",
     "prepush": "yarn lint && yarn type-check && jest --changedSince main",
-    "prepack": "cp ../package.json ./package.json"
+    "postversion": "cp package.json ./dist/package.json"
   },
   "peerDependencies": {
     "@jupiterone/integration-sdk-core": "^8.8.0"


### PR DESCRIPTION
Operations using `prepack` weren't fully changing version prior to `npm publish`.  Testing in a separate repo has shown that `postversion` is the better option.