### PR TITLE
THC-1724 - Check for duplicate keys in org->repo mapped relationship

### DIFF
--- a/src/steps/repository/index.ts
+++ b/src/steps/repository/index.ts
@@ -32,32 +32,29 @@ export async function buildOrgRepoRelationship({
 
       await apiClient.iterateOrganizationRepositories(async (repo) => {
         if (!repo.url) return;
-        try {
-          await jobState.addRelationship(
-            createMappedRelationship({
-              _class: MappedRelationships.ORGANIZATION_HAS_REPO._class,
-              _type: MappedRelationships.ORGANIZATION_HAS_REPO._type,
-              _mapping: {
-                relationshipDirection:
-                  MappedRelationships.ORGANIZATION_HAS_REPO.direction,
-                sourceEntityKey: orgEntity._key,
-                targetFilterKeys: [['webLink', '_class']],
-                targetEntity: {
-                  _class: 'CodeRepo',
-                  webLink: repo.url,
-                },
-              },
-            }),
+
+        const orgHasRepo = createMappedRelationship({
+          _class: MappedRelationships.ORGANIZATION_HAS_REPO._class,
+          _type: MappedRelationships.ORGANIZATION_HAS_REPO._type,
+          _mapping: {
+            relationshipDirection:
+              MappedRelationships.ORGANIZATION_HAS_REPO.direction,
+            sourceEntityKey: orgEntity._key,
+            targetFilterKeys: [['webLink', '_class']],
+            targetEntity: {
+              _class: 'CodeRepo',
+              webLink: repo.url,
+            },
+          },
+        });
+        if (jobState.hasKey(orgHasRepo._key)) {
+          logger.info(
+            { _key: orgHasRepo._key },
+            'Duplicated key detected while creating org has repo.  Skipping.',
           );
-        } catch (error) {
-          if (error.code == 'DUPLICATE_KEY_DETECTED') {
-            logger.info(
-              { error, repo },
-              'Duplicated key detected while creating org has repo.',
-            );
-          } else {
-            throw error;
-          }
+          return;
+        } else {
+          await jobState.addRelationship(orgHasRepo);
         }
       });
     },


### PR DESCRIPTION
We have recently seen some issues with data synchronization from downstream systems.  I'd like to make this small change to see if we're not properly handling the case where a duplicate key error is caught and allowed to proceed.  The jobState in that case may have partial data that's causing us issues during data storage and replication.